### PR TITLE
Prevent `is_verified` to become `False` when editing user's email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 **Note**: Numbers like (\#123) point to closed Pull Requests on the fractal repository.
 
+# 1.4.4 (unreleased)
+
+* Require user's verification to be specified when editing user email (\#620).
+
 # 1.4.3
 
 * Make `fractal-client` a fully synchronous client, by removing all `async`/`await` (\#592).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 1.4.4 (unreleased)
 
-* Require user's verification to be specified when editing user email (\#620).
+* Require user's verification to be specified when editing user's email (\#620).
 
 # 1.4.3
 

--- a/fractal_client/cmd/_user.py
+++ b/fractal_client/cmd/_user.py
@@ -124,6 +124,7 @@ def user_edit(
     res = client.patch(
         f"{settings.FRACTAL_SERVER}/auth/users/{user_id}/", json=user_update
     )
+    new_user = check_response(res, expected_status_code=200)
 
     if new_email is not None:
         # issue 619
@@ -131,8 +132,7 @@ def user_edit(
             f"{settings.FRACTAL_SERVER}/auth/users/{user_id}/",
             json=dict(is_verified=user_update["is_verified"]),
         )
-
-    new_user = check_response(res, expected_status_code=200)
+        new_user = check_response(res, expected_status_code=200)
 
     return RichJsonInterface(retcode=0, data=new_user)
 

--- a/fractal_client/cmd/_user.py
+++ b/fractal_client/cmd/_user.py
@@ -92,6 +92,7 @@ def user_edit(
     user_update = dict()
     if new_email is not None:
         if (make_verified is False) and (remove_verified is False):
+            # issue 619
             return PrintInterface(
                 retcode=1,
                 data=(
@@ -119,9 +120,18 @@ def user_edit(
 
     if not user_update:
         return PrintInterface(retcode=1, data="Nothing to update")
+
     res = client.patch(
         f"{settings.FRACTAL_SERVER}/auth/users/{user_id}/", json=user_update
     )
+
+    if new_email is not None:
+        # issue 619
+        res = client.patch(
+            f"{settings.FRACTAL_SERVER}/auth/users/{user_id}/",
+            json=dict(is_verified=user_update["is_verified"]),
+        )
+
     new_user = check_response(res, expected_status_code=200)
 
     return RichJsonInterface(retcode=0, data=new_user)

--- a/fractal_client/cmd/_user.py
+++ b/fractal_client/cmd/_user.py
@@ -92,7 +92,9 @@ def user_edit(
     user_update = dict()
     if new_email is not None:
         if (make_verified is False) and (remove_verified is False):
-            # issue 619
+            # Since `fastapi-users` sets `is_verified` to `False` each time the
+            # email is updated, we force the user to make explicit whether the
+            # account is verified or not.
             return PrintInterface(
                 retcode=1,
                 data=(
@@ -127,7 +129,8 @@ def user_edit(
     new_user = check_response(res, expected_status_code=200)
 
     if new_email is not None:
-        # issue 619
+        # Since `fastapi-users` sets `is_verified` to `False` each time the
+        # email is updated, we set `is_verified` as specified by the user.
         res = client.patch(
             f"{settings.FRACTAL_SERVER}/auth/users/{user_id}/",
             json=dict(is_verified=user_update["is_verified"]),

--- a/fractal_client/cmd/_user.py
+++ b/fractal_client/cmd/_user.py
@@ -91,6 +91,14 @@ def user_edit(
 
     user_update = dict()
     if new_email is not None:
+        if (make_verified is False) and (remove_verified is False):
+            return PrintInterface(
+                retcode=1,
+                data=(
+                    "Cannot use `--new-email` without `--make-verified` or "
+                    "`--remove-verified`"
+                ),
+            )
         user_update["email"] = new_email
     if new_password is not None:
         user_update["password"] = new_password

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -143,6 +143,10 @@ def test_edit_as_superuser(
         assert not res.data["is_verified"]
     else:
         assert res.retcode == 1
+        assert res.data == (
+            "Cannot use `--new-email` without `--make-verified` or "
+            "`--remove-verified`"
+        )
 
     BAD_CACHE_DIR = "not_absolute"
     with pytest.raises(SystemExit):


### PR DESCRIPTION
closes #619 

## Checklist before merging
- [x] I added an appropriate entry to `CHANGELOG.md`
