### PR TITLE
[auto] Update dependencies in `poetry.lock`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -680,7 +680,7 @@ postgres = ["asyncpg (>=0.29.0,<0.30.0)", "psycopg2 (>=2.9.5,<3.0.0)"]
 type = "git"
 url = "https://github.com/fractal-analytics-platform/fractal-server.git"
 reference = "main"
-resolved_reference = "bf654857d0c8e623c6cc07625f12e3d10a463fac"
+resolved_reference = "aee767713559aff70ad58ffe56eca07b00548bce"
 
 [[package]]
 name = "ghp-import"
@@ -772,13 +772,13 @@ test = ["objgraph", "psutil"]
 
 [[package]]
 name = "griffe"
-version = "0.41.3"
+version = "0.42.0"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "griffe-0.41.3-py3-none-any.whl", hash = "sha256:27b4610f1ba6e5d039e9f0a2c97232e13463df75e53cb1833e0679f3377b9de2"},
-    {file = "griffe-0.41.3.tar.gz", hash = "sha256:9edcfa9f57f4d9c5fcc6d5ce067c67a685b7101a21a7d11848ce0437368e474c"},
+    {file = "griffe-0.42.0-py3-none-any.whl", hash = "sha256:384df6b802a60f70e65fdb7e83f5b27e2da869a12eac85b25b55250012dbc263"},
+    {file = "griffe-0.42.0.tar.gz", hash = "sha256:fb83ee602701ffdf99c9a6bf5f0a5a3bd877364b3bffb2c451dc8fbd9645b0cf"},
 ]
 
 [package.dependencies]
@@ -880,22 +880,22 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "7.0.1"
+version = "7.0.2"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-7.0.1-py3-none-any.whl", hash = "sha256:4805911c3a4ec7c3966410053e9ec6a1fecd629117df5adee56dfc9432a1081e"},
-    {file = "importlib_metadata-7.0.1.tar.gz", hash = "sha256:f238736bb06590ae52ac1fab06a3a9ef1d8dce2b7a35b5ab329371d6c8f5d2cc"},
+    {file = "importlib_metadata-7.0.2-py3-none-any.whl", hash = "sha256:f4bc4c0c070c490abf4ce96d715f68e95923320370efb66143df00199bb6c100"},
+    {file = "importlib_metadata-7.0.2.tar.gz", hash = "sha256:198f568f3230878cb1b44fbd7975f87906c22336dba2e4a7f05278c281fbd792"},
 ]
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
 
 [[package]]
 name = "iniconfig"


### PR DESCRIPTION
### Updated dependencies:

```bash
Updating dependencies
Resolving dependencies...

Package operations: 0 installs, 1 update, 0 removals

  • Updating fractal-server (1.4.9 bf65485 -> 1.4.9 aee7677)

Writing lock file
```

### Outdated dependencies _before_ PR:

```bash
aiosqlite        0.19.0        0.20.0        asyncio bridge to the standard ...
bcrypt           4.0.1         4.1.2         Modern password hashing for you...
bumpver          2022.1120     2023.1129     Bump version numbers in project...
cloudpickle      2.2.1         3.0.0         Extended pickling support for P...
coverage         6.5.0         7.4.3         Code coverage measurement for P...
devtools         0.9.0         0.12.2        Python's missing debug print co...
executing        0.10.0        2.0.1         Get the currently executing AST...
fastapi          0.109.2       0.110.0       FastAPI framework, high perform...
fastapi-users    12.1.3        13.0.0        Ready-to-use and customizable u...
fractal-server   1.4.9 bf65485 1.4.9 aee7677 Server component of the Fractal...
httpcore         0.16.3        1.0.4         A minimal low-level HTTP client.
httpx            0.23.3        0.27.0        The next generation HTTP client.
packaging        23.2          24.0          Core utilities for Python packages
pre-commit       2.21.0        3.6.2         A framework for managing and ma...
pydantic         1.10.14       2.6.3         Data validation and settings ma...
pytest           7.4.4         8.1.1         pytest: simple powerful testing...
python-dotenv    0.21.1        1.0.1         Read key-value pairs from a .en...
python-multipart 0.0.7         0.0.9         A streaming multipart parser fo...
rfc3986          1.5.0         2.0.0         Validating URI References per R...
rich             12.6.0        13.7.1        Render rich text, tables, progr...
sqlmodel         0.0.14        0.0.16        SQLModel, SQL databases in Pyth...
starlette        0.36.3        0.37.2        The little ASGI library that sh...
uvicorn          0.27.1        0.28.0        The lightning-fast ASGI server.
```

### Outdated dependencies _after_ PR:

```bash
aiosqlite        0.19.0    0.20.0    asyncio bridge to the standard sqlite3 ...
bcrypt           4.0.1     4.1.2     Modern password hashing for your softwa...
bumpver          2022.1120 2023.1129 Bump version numbers in project files.
cloudpickle      2.2.1     3.0.0     Extended pickling support for Python ob...
coverage         6.5.0     7.4.3     Code coverage measurement for Python
devtools         0.9.0     0.12.2    Python's missing debug print command, a...
executing        0.10.0    2.0.1     Get the currently executing AST node of...
fastapi          0.109.2   0.110.0   FastAPI framework, high performance, ea...
fastapi-users    12.1.3    13.0.0    Ready-to-use and customizable users man...
httpcore         0.16.3    1.0.4     A minimal low-level HTTP client.
httpx            0.23.3    0.27.0    The next generation HTTP client.
packaging        23.2      24.0      Core utilities for Python packages
pre-commit       2.21.0    3.6.2     A framework for managing and maintainin...
pydantic         1.10.14   2.6.3     Data validation and settings management...
pytest           7.4.4     8.1.1     pytest: simple powerful testing with Py...
python-dotenv    0.21.1    1.0.1     Read key-value pairs from a .env file a...
python-multipart 0.0.7     0.0.9     A streaming multipart parser for Python
rfc3986          1.5.0     2.0.0     Validating URI References per RFC 3986
rich             12.6.0    13.7.1    Render rich text, tables, progress bars...
sqlmodel         0.0.14    0.0.16    SQLModel, SQL databases in Python, desi...
starlette        0.36.3    0.37.2    The little ASGI library that shines.
uvicorn          0.27.1    0.28.0    The lightning-fast ASGI server.
```

_Note: there may be dependencies in the table above which were not updated as part of this PR.
The reason is they require manual updating due to the way they are pinned._