### PR TITLE
[auto] Update dependencies in `poetry.lock`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -680,7 +680,7 @@ postgres = ["asyncpg (>=0.29.0,<0.30.0)", "psycopg2 (>=2.9.5,<3.0.0)"]
 type = "git"
 url = "https://github.com/fractal-analytics-platform/fractal-server.git"
 reference = "main"
-resolved_reference = "b871369005a3e37b035afe6d2a7f675a64d8895d"
+resolved_reference = "3504c3fda946a362edb6f17e6da90a78f95c7bad"
 
 [[package]]
 name = "ghp-import"
@@ -1359,13 +1359,13 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "pycparser"
-version = "2.21"
+version = "2.22"
 description = "C parser in Python"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.8"
 files = [
-    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
-    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+    {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
+    {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
 ]
 
 [[package]]


### PR DESCRIPTION
### Updated dependencies:

```bash
Updating dependencies
Resolving dependencies...

Package operations: 0 installs, 2 updates, 0 removals

  • Updating pycparser (2.21 -> 2.22)
  • Updating fractal-server (1.4.10 b871369 -> 1.4.10 3504c3f)

Writing lock file
```

### Outdated dependencies _before_ PR:

```bash
aiosqlite        0.19.0         0.20.0         asyncio bridge to the standar...
bcrypt           4.0.1          4.1.2          Modern password hashing for y...
bumpver          2022.1120      2023.1129      Bump version numbers in proje...
cloudpickle      2.2.1          3.0.0          Extended pickling support for...
coverage         6.5.0          7.4.4          Code coverage measurement for...
devtools         0.9.0          0.12.2         Python's missing debug print ...
executing        0.10.0         2.0.1          Get the currently executing A...
fastapi          0.109.2        0.110.1        FastAPI framework, high perfo...
fastapi-users    12.1.3         13.0.0         Ready-to-use and customizable...
fractal-server   1.4.10 b871369 1.4.10 3504c3f Server component of the Fract...
httpcore         0.16.3         1.0.5          A minimal low-level HTTP client.
httpx            0.23.3         0.27.0         The next generation HTTP client.
packaging        23.2           24.0           Core utilities for Python pac...
pre-commit       2.21.0         3.7.0          A framework for managing and ...
pycparser        2.21           2.22           C parser in Python
pydantic         1.10.14        2.6.4          Data validation and settings ...
pytest           7.4.4          8.1.1          pytest: simple powerful testi...
python-dotenv    0.21.1         1.0.1          Read key-value pairs from a ....
python-multipart 0.0.7          0.0.9          A streaming multipart parser ...
rfc3986          1.5.0          2.0.0          Validating URI References per...
rich             12.6.0         13.7.1         Render rich text, tables, pro...
sqlmodel         0.0.14         0.0.16         SQLModel, SQL databases in Py...
starlette        0.36.3         0.37.2         The little ASGI library that ...
uvicorn          0.27.1         0.29.0         The lightning-fast ASGI server.
```

### Outdated dependencies _after_ PR:

```bash
aiosqlite        0.19.0    0.20.0    asyncio bridge to the standard sqlite3 ...
bcrypt           4.0.1     4.1.2     Modern password hashing for your softwa...
bumpver          2022.1120 2023.1129 Bump version numbers in project files.
cloudpickle      2.2.1     3.0.0     Extended pickling support for Python ob...
coverage         6.5.0     7.4.4     Code coverage measurement for Python
devtools         0.9.0     0.12.2    Python's missing debug print command, a...
executing        0.10.0    2.0.1     Get the currently executing AST node of...
fastapi          0.109.2   0.110.1   FastAPI framework, high performance, ea...
fastapi-users    12.1.3    13.0.0    Ready-to-use and customizable users man...
httpcore         0.16.3    1.0.5     A minimal low-level HTTP client.
httpx            0.23.3    0.27.0    The next generation HTTP client.
packaging        23.2      24.0      Core utilities for Python packages
pre-commit       2.21.0    3.7.0     A framework for managing and maintainin...
pydantic         1.10.14   2.6.4     Data validation and settings management...
pytest           7.4.4     8.1.1     pytest: simple powerful testing with Py...
python-dotenv    0.21.1    1.0.1     Read key-value pairs from a .env file a...
python-multipart 0.0.7     0.0.9     A streaming multipart parser for Python
rfc3986          1.5.0     2.0.0     Validating URI References per RFC 3986
rich             12.6.0    13.7.1    Render rich text, tables, progress bars...
sqlmodel         0.0.14    0.0.16    SQLModel, SQL databases in Python, desi...
starlette        0.36.3    0.37.2    The little ASGI library that shines.
uvicorn          0.27.1    0.29.0    The lightning-fast ASGI server.
```

_Note: there may be dependencies in the table above which were not updated as part of this PR.
The reason is they require manual updating due to the way they are pinned._